### PR TITLE
changes for tidymodels/tune#265

### DIFF
--- a/R/parsnip-arima_boost_data.R
+++ b/R/parsnip-arima_boost_data.R
@@ -17,6 +17,7 @@ make_arima_boost <- function() {
     parsnip::set_model_engine("arima_boost", mode = "regression", eng = "auto_arima_xgboost")
     parsnip::set_dependency("arima_boost", "auto_arima_xgboost", "forecast")
     parsnip::set_dependency("arima_boost", "auto_arima_xgboost", "xgboost")
+    parsnip::set_dependency("arima_boost", "auto_arima_xgboost", "modeltime")
 
     # * Args - ARIMA ----
     parsnip::set_model_arg(
@@ -193,6 +194,7 @@ make_arima_boost <- function() {
     parsnip::set_model_engine("arima_boost", mode = "regression", eng = "arima_xgboost")
     parsnip::set_dependency("arima_boost", "arima_xgboost", "forecast")
     parsnip::set_dependency("arima_boost", "arima_xgboost", "xgboost")
+    parsnip::set_dependency("arima_boost", "arima_xgboost", "modeltime")
 
     # * Args - ARIMA ----
     parsnip::set_model_arg(

--- a/R/parsnip-arima_reg_data.R
+++ b/R/parsnip-arima_reg_data.R
@@ -16,6 +16,7 @@ make_arima_reg <- function() {
     # * Model ----
     parsnip::set_model_engine("arima_reg", mode = "regression", eng = "arima")
     parsnip::set_dependency("arima_reg", "arima", "forecast")
+    parsnip::set_dependency("arima_reg", "arima", "modeltime")
 
     # * Args ----
     parsnip::set_model_arg(
@@ -129,6 +130,7 @@ make_arima_reg <- function() {
     # * Model ----
     parsnip::set_model_engine("arima_reg", mode = "regression", eng = "auto_arima")
     parsnip::set_dependency("arima_reg", "auto_arima", "forecast")
+    parsnip::set_dependency("arima_reg", "auto_arima", "modeltime")
 
     # * Args ----
     parsnip::set_model_arg(

--- a/R/parsnip-exp_smoothing_data.R
+++ b/R/parsnip-exp_smoothing_data.R
@@ -16,6 +16,7 @@ make_exp_smoothing <- function() {
     # * Model ----
     parsnip::set_model_engine("exp_smoothing", mode = "regression", eng = "ets")
     parsnip::set_dependency("exp_smoothing", "ets", "forecast")
+    parsnip::set_dependency("exp_smoothing", "ets", "modeltime")
 
     # * Args ----
     parsnip::set_model_arg(

--- a/R/parsnip-prophet_boost_data.R
+++ b/R/parsnip-prophet_boost_data.R
@@ -16,6 +16,7 @@ make_prophet_boost <- function() {
     # * Model ----
     parsnip::set_model_engine("prophet_boost", mode = "regression", eng = "prophet_xgboost")
     parsnip::set_dependency("prophet_boost", eng = "prophet_xgboost", pkg = "prophet")
+    parsnip::set_dependency("prophet_boost", eng = "prophet_xgboost", pkg = "modeltime")
 
     # * Args - Prophet ----
     parsnip::set_model_arg(

--- a/R/parsnip-prophet_reg_data.R
+++ b/R/parsnip-prophet_reg_data.R
@@ -16,6 +16,7 @@ make_prophet_reg <- function() {
     # * Model ----
     parsnip::set_model_engine("prophet_reg", mode = "regression", eng = "prophet")
     parsnip::set_dependency("prophet_reg", eng = "prophet", pkg = "prophet")
+    parsnip::set_dependency("prophet_reg", eng = "prophet", pkg = "modeltime")
 
     # * Args ----
     parsnip::set_model_arg(

--- a/R/parsnip-seasonal_reg_data.R
+++ b/R/parsnip-seasonal_reg_data.R
@@ -16,6 +16,7 @@ make_seasonal_reg <- function() {
     # * Model ----
     parsnip::set_model_engine("seasonal_reg", mode = "regression", eng = "tbats")
     parsnip::set_dependency("seasonal_reg", "tbats", "forecast")
+    parsnip::set_dependency("seasonal_reg", "tbats", "modeltime")
 
     # * Args ----
     parsnip::set_model_arg(
@@ -94,6 +95,7 @@ make_seasonal_reg <- function() {
     # * Model ----
     parsnip::set_model_engine("seasonal_reg", mode = "regression", eng = "stlm_ets")
     parsnip::set_dependency("seasonal_reg", "stlm_ets", "forecast")
+    parsnip::set_dependency("seasonal_reg", "stlm_ets", "modeltime")
 
     # * Args ----
     parsnip::set_model_arg(
@@ -172,6 +174,7 @@ make_seasonal_reg <- function() {
     # * Model ----
     parsnip::set_model_engine("seasonal_reg", mode = "regression", eng = "stlm_arima")
     parsnip::set_dependency("seasonal_reg", "stlm_arima", "forecast")
+    parsnip::set_dependency("seasonal_reg", "stlm_arima", "modeltime")
 
     # * Args ----
     parsnip::set_model_arg(


### PR DESCRIPTION
This should enable parallel processing with psock clusters. I'll make a different PR for some `timetk` changes too.  

I don't have any examples using `modeltime` and `tune` so it would be helpful if you could test this. 

```r
library(tidymodels)
library(modeltime)

library(doParallel)
cl <- makePSOCKcluster(2)
registerDoParallel(cl)

# some tuning code using 1+ of modeltime models

stopCluster(cl)
```