### PR TITLE
Added encoding information to work with devel version of `parsnip`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,7 +21,7 @@ Depends:
 Imports:
     StanHeaders,
     timetk (>= 2.1.0),
-    parsnip (>= 0.1.3),
+    parsnip (>= 0.1.3.9000),
     dials,
     yardstick,
     workflows (>= 0.1.3),
@@ -64,5 +64,5 @@ Suggests:
     rmarkdown,
     webshot
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.1
 VignetteBuilder: knitr
+Remotes: tidymodels/parsnip

--- a/R/parsnip-arima_boost_data.R
+++ b/R/parsnip-arima_boost_data.R
@@ -151,7 +151,8 @@ make_arima_boost <- function() {
         options = list(
             predictor_indicators = "none",
             compute_intercept    = FALSE,
-            remove_intercept     = FALSE
+            remove_intercept     = FALSE,
+            allow_sparse_x       = FALSE
         )
     )
 
@@ -329,7 +330,8 @@ make_arima_boost <- function() {
         options = list(
             predictor_indicators = "none",
             compute_intercept    = FALSE,
-            remove_intercept     = FALSE
+            remove_intercept     = FALSE,
+            allow_sparse_x       = FALSE
         )
     )
 

--- a/R/parsnip-arima_reg_data.R
+++ b/R/parsnip-arima_reg_data.R
@@ -90,7 +90,8 @@ make_arima_reg <- function() {
         options = list(
             predictor_indicators = "none",
             compute_intercept    = FALSE,
-            remove_intercept     = FALSE
+            remove_intercept     = FALSE,
+            allow_sparse_x       = FALSE
         )
     )
 
@@ -204,7 +205,8 @@ make_arima_reg <- function() {
         options = list(
             predictor_indicators = "none",
             compute_intercept    = FALSE,
-            remove_intercept     = FALSE
+            remove_intercept     = FALSE,
+            allow_sparse_x       = FALSE
         )
     )
 

--- a/R/parsnip-exp_smoothing_data.R
+++ b/R/parsnip-exp_smoothing_data.R
@@ -70,7 +70,8 @@ make_exp_smoothing <- function() {
         options = list(
             predictor_indicators = "none",
             compute_intercept    = FALSE,
-            remove_intercept     = FALSE
+            remove_intercept     = FALSE,
+            allow_sparse_x       = FALSE
         )
     )
 

--- a/R/parsnip-nnetar_reg_data.R
+++ b/R/parsnip-nnetar_reg_data.R
@@ -92,7 +92,8 @@ make_nnetar_reg <- function() {
         options = list(
             predictor_indicators = "none",
             compute_intercept    = FALSE,
-            remove_intercept     = FALSE
+            remove_intercept     = FALSE,
+            allow_sparse_x       = FALSE
         )
     )
 

--- a/R/parsnip-prophet_boost_data.R
+++ b/R/parsnip-prophet_boost_data.R
@@ -203,7 +203,8 @@ make_prophet_boost <- function() {
         options = list(
             predictor_indicators = "none",
             compute_intercept    = FALSE,
-            remove_intercept     = FALSE
+            remove_intercept     = FALSE,
+            allow_sparse_x       = FALSE
         )
     )
 

--- a/R/parsnip-prophet_reg_data.R
+++ b/R/parsnip-prophet_reg_data.R
@@ -135,7 +135,8 @@ make_prophet_reg <- function() {
         options = list(
             predictor_indicators = "none",
             compute_intercept    = FALSE,
-            remove_intercept     = FALSE
+            remove_intercept     = FALSE,
+            allow_sparse_x       = FALSE
         )
     )
 

--- a/R/parsnip-seasonal_reg_data.R
+++ b/R/parsnip-seasonal_reg_data.R
@@ -54,7 +54,8 @@ make_seasonal_reg <- function() {
         options = list(
             predictor_indicators = "none",
             compute_intercept    = FALSE,
-            remove_intercept     = FALSE
+            remove_intercept     = FALSE,
+            allow_sparse_x       = FALSE
         )
     )
 
@@ -133,7 +134,8 @@ make_seasonal_reg <- function() {
         options = list(
             predictor_indicators = "none",
             compute_intercept    = FALSE,
-            remove_intercept     = FALSE
+            remove_intercept     = FALSE,
+            allow_sparse_x       = FALSE
         )
     )
 
@@ -212,7 +214,8 @@ make_seasonal_reg <- function() {
         options = list(
             predictor_indicators = "none",
             compute_intercept    = FALSE,
-            remove_intercept     = FALSE
+            remove_intercept     = FALSE,
+            allow_sparse_x       = FALSE
         )
     )
 

--- a/vignettes/extending-modeltime.Rmd
+++ b/vignettes/extending-modeltime.Rmd
@@ -412,7 +412,8 @@ parsnip::set_encoding(
   options = list(
     predictor_indicators = "none",
     compute_intercept = FALSE,
-    remove_intercept = FALSE
+    remove_intercept = FALSE,
+    allow_sparse_x = FALSE
   )
 )
 ```


### PR DESCRIPTION
Just added the new `allow_sparse_x` option. 

Depends on devel `parsnip` now. We'll probably submit this month. 