### PR TITLE
fixes business-science#79

### DIFF
--- a/R/modeltime-recursive.R
+++ b/R/modeltime-recursive.R
@@ -408,7 +408,7 @@ predict_recursive_model_fit <- function(object, new_data, type = NULL, opts = li
         .nth_slice <- .transform(.temp_new_data, nrow(new_data), i)
 
         .preds[i,] <- new_data[i, y_var] <- pred_fun(
-            object, new_data = .nth_slice,
+            object, new_data = .nth_slice[names(.first_slice)],
             type = type, opts = opts, ...
         )
     }


### PR DESCRIPTION
Hi @mdancho84 ,

I have fixed the GH issue #79 . We need to ensure that when predicting each step in the recursive algorithm we are using the same variables as those in new_data (in this case we can ensure this from the variable .first_slice). In the particular example being solved, three additional unnecessary fields were being generated:

- The date that is removed in the recipe but not removed from the train_tail.

- Rolling_lag_12 variables that additional variables are generated at each step when a "contains" is used in the function definition (so additional variables are generated that are not needed by mistake, since the model is only trained with one).

- The "value" field is also not being used and yet it is put in when generating the predictions.

The proposed solution puts an end to all these problems.

Regards,