### PR TITLE
Use `step_rm()` to get rid of `date` rather than updating its role

### DIFF
--- a/tests/testthat/test-panel-data.R
+++ b/tests/testthat/test-panel-data.R
@@ -32,13 +32,13 @@ wflw_fit_prophet <- workflow() %>%
 set.seed(123)
 wflw_fit_svm <- workflow() %>%
     add_model(svm_rbf() %>% set_engine("kernlab")) %>%
-    add_recipe(recipe_spec %>% update_role(date, new_role = "ID")) %>%
+    add_recipe(recipe_spec %>% step_rm(date)) %>%
     fit(data_set)
 
 # set.seed(123)
 # wflw_fit_xgb <- workflow() %>%
 #     add_model(boost_tree() %>% set_engine("xgboost")) %>%
-#     add_recipe(recipe_spec %>% update_role(date, new_role = "ID")) %>%
+#     add_recipe(recipe_spec %>% step_rm(date)) %>%
 #     fit(data_set)
 
 # PANEL DATA - FORECAST JUMBLED ----


### PR DESCRIPTION
Hi @mdancho84,

We are working on releasing the next version of hardhat (and a number of other tidymodels releases following that).

The revdep check for hardhat shows an issue with modeltime.

I am planning on releasing hardhat on Monday. You were the only failure, so if you have time to send a CRAN release in with this fix before that then that would be great, but if not then I will go ahead and send it in anyways and just let CRAN know that I have done this PR.

It is related to the first bullet point here, about non-standard recipes roles:
https://github.com/tidymodels/hardhat/blob/main/NEWS.md#hardhat-development-version

You can reproduce it by installing the development version of hardhat with `pak::pak("tidymodels/hardhat")` and running your tests. You should get something obscure like:

```r
*   checking tests ... ERROR
    ```
      Running ‘testthat.R’
    Running the tests in ‘tests/testthat.R’ failed.
    Last 13 lines of output:
      x[2]: NA
      y[2]: "Test"
      ── Failure (test-panel-data.R:65:5): Panel Data - Forecast Jumbled ─────────────
      all(!is.na(accuracy_tbl$mae)) is not TRUE
      
      `actual`:   FALSE
      `expected`: TRUE 
      ── Failure (test-panel-data.R:90:5): Panel Data - Forecast Jumbled ─────────────
      nrow(svm_tbl) not equal to nrow(data_set).
      1/1 mismatches
      [1] 0 - 1574 == -1574
      
      [ FAIL 3 | WARN 3 | SKIP 22 | PASS 522 ]
      Error: Test failures
      Execution halted
    ```
```

In one of your tests you use `update_role(date, new_role = "ID")` to prevent `date` from showing up as a predictor in the data that eventually gets passed to the model. The better approach is to use `step_rm(date)` in this case.

The problem is that `date` is actually used as a `"predictor"` in that in `recipe_spec` because you use `date` to derive other predictors (like `date_num` and the `month_lbl` column). `"ID"` columns shouldn't be involved in the generation of other predictors.

The change in hardhat means that only `"predictor"` roles are utilized in `hardhat::forge()` by default, which means that when the prediction time data is eventually run through the recipe, the `date` column won't be available (even if it was there to begin with, it will get subset out because it is an `"ID"` not a `"predictor"`) and you'll get a failure in the recipe step that tries to create `date_num`. This change was required to support our upcoming roll out of case weights, and honestly should have been the default all along.

One thing that we haven't made clear until now is that `update_role()` actually runs _first_ before any of the steps have been run. So you aren't really updating `date` to become an `"ID"` role _after_ it has been used as a `"predictor"` to create the other columns, you are actually starting `date` off as an `"ID"` _before_ any of the steps have been run. This is why it is better to just leave `date` as a `"predictor"` column, use it to derive the other required predictors, and then remove it from the recipe after you are done with it if you don't want it to get passed along to the model.