### PR TITLE
better detect_net() implementation #188

### DIFF
--- a/R/modeltime-forecast.R
+++ b/R/modeltime-forecast.R
@@ -1041,10 +1041,12 @@ mdl_time_forecast.workflow <- function(object, calibration_data, new_data = NULL
 }
 
 
-detect_net <- function(object){
-    res <- class(object) %>%
-        stringr::str_detect(., "net") %>%
-        sum()
 
-    if (res >= 1) {TRUE} else {FALSE}
+detect_net <- function(object){
+    if (inherits(object, "_fishnet") || inherits(object, "_elnet") || inherits(object, "_multnet") || inherits(object, "_lognet")){
+        res <- TRUE
+    } else {
+        res <- FALSE
+    }
+    return(res)
 }


### PR DESCRIPTION
Hi @mdancho84 ,

I just modified the `detect_net()` function to just look for the classes of the following parsnip functions when they have glmnet engine:

- linear_reg
- logistic_reg
- poisson_reg
- multinom_reg

I got the information from here filtering the engine:

https://www.tidymodels.org/find/parsnip/

Regards,

