### PR TITLE
Explicitly set the `mode` in parsnip model specifications

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ Imports:
     parsnip (>= 0.2.1),
     dials,
     yardstick (>= 0.0.8),
-    workflows (>= 0.1.3),
+    workflows (>= 1.0.0.9000),
     hardhat (>= 1.0.0),
     rlang (>= 0.1.2),
     glue,
@@ -83,4 +83,5 @@ Suggests:
 Roxygen: list(markdown = TRUE)
 VignetteBuilder: knitr
 RoxygenNote: 7.2.0
-
+Remotes:
+    tidymodels/workflows

--- a/tests/testthat/test-conf_by_id.R
+++ b/tests/testthat/test-conf_by_id.R
@@ -26,7 +26,7 @@ test_that("Confidence and Accuracy by ID", {
 
     wflw_xgb <- workflow() %>%
         add_model(
-            boost_tree() %>% set_engine("xgboost")
+            boost_tree("regression") %>% set_engine("xgboost")
         ) %>%
         add_recipe(rec_obj) %>%
         fit(training(splits))

--- a/tests/testthat/test-modeltime_residuals.R
+++ b/tests/testthat/test-modeltime_residuals.R
@@ -31,7 +31,7 @@ testthat::test_that("modeltime_residuals(): Returns correct order", {
     # Workflow
     wflw_xgb <- workflow() %>%
         add_model(
-            boost_tree() %>% set_engine("xgboost")
+            boost_tree("regression") %>% set_engine("xgboost")
         ) %>%
         add_recipe(rec_obj) %>%
         fit(training(splits))

--- a/tests/testthat/test-modeltime_table-forecast-accuracy-refitting.R
+++ b/tests/testthat/test-modeltime_table-forecast-accuracy-refitting.R
@@ -323,7 +323,7 @@ test_that("Models for Mega Test", {
 
     # * randomForest (workflow) ----
 
-    model_spec <- rand_forest() %>%
+    model_spec <- rand_forest("regression") %>%
         set_engine("randomForest")
 
     recipe_spec <- recipe(value ~ date, data = training(splits)) %>%
@@ -351,7 +351,7 @@ test_that("Models for Mega Test", {
 
     # * XGBoost (workflow) ----
 
-    model_spec <- boost_tree() %>%
+    model_spec <- boost_tree("regression") %>%
         set_engine("xgboost", objective = "reg:squarederror")
 
     recipe_spec <- recipe(value ~ date, data = training(splits)) %>%

--- a/tests/testthat/test-nested-modeltime.R
+++ b/tests/testthat/test-nested-modeltime.R
@@ -73,7 +73,7 @@ wflw_xgb <- workflow() %>%
 recipe_bad <- recipe(value ~ ., extract_nested_train_split(nested_data_tbl))
 
 wflw_bad <- workflow() %>%
-    add_model(boost_tree()) %>%
+    add_model(boost_tree("regression") %>% set_engine("xgboost")) %>%
     add_recipe(recipe_bad)
 
 # * Prophet ----

--- a/tests/testthat/test-panel-data.R
+++ b/tests/testthat/test-panel-data.R
@@ -31,7 +31,7 @@ wflw_fit_prophet <- workflow() %>%
 
 set.seed(123)
 wflw_fit_svm <- workflow() %>%
-    add_model(svm_rbf() %>% set_engine("kernlab")) %>%
+    add_model(svm_rbf(mode = "regression") %>% set_engine("kernlab")) %>%
     add_recipe(recipe_spec %>% step_rm(date)) %>%
     fit(data_set)
 

--- a/tests/testthat/test-refit-parallel.R
+++ b/tests/testthat/test-refit-parallel.R
@@ -28,7 +28,7 @@ testthat::test_that("refit works in parallel", {
 
     set.seed(123)
     wflw_fit_svm <- workflow() %>%
-        add_model(svm_rbf() %>% set_engine("kernlab")) %>%
+        add_model(svm_rbf("regression") %>% set_engine("kernlab")) %>%
         add_recipe(recipe_spec %>% update_role(date, new_role = "ID")) %>%
         fit(data_set)
 

--- a/vignettes/modeling-panel-data.Rmd
+++ b/vignettes/modeling-panel-data.Rmd
@@ -182,7 +182,7 @@ We'll create an `xgboost` workflow by fitting the default xgboost model to our d
 # Workflow
 wflw_xgb <- workflow() %>%
     add_model(
-        boost_tree() %>% set_engine("xgboost")
+        boost_tree("regression") %>% set_engine("xgboost")
     ) %>%
     add_recipe(rec_obj) %>%
     fit(training(splits))


### PR DESCRIPTION
workflows 1.1.0 is about to be released. In this version of workflows (and the next version of parsnip), we now require that the `mode` argument of parsnip model specifications must be set to something other than `"unknown"`. `"unknown"` is the default for some models that can do both classification/regression, like `boost_tree()`, and we need the user to be explicit about what kind of mode they are using.

See the second NEWS bullet here:
https://github.com/tidymodels/workflows/blob/main/NEWS.md#workflows-development-version

3 of your packages were affected by this:
- modeltime
- modeltime.resample
- modeltime.ensemble

The fix is fairly simple, you just need to explicitly state the `mode`.

I've made the fix for modeltime here, but you'll need to update modeltime.resample and modeltime.ensemble as well.

I have added a Remote on the dev version of workflows to show that everything is working now, but you can remove the remote and go ahead and send modeltime to CRAN at any time (along with the other two packages).

I will probably send workflows in today or tomorrow.

Thanks!