### PR TITLE
fix: specify pkg for model inclusions to parsnip

### DIFF
--- a/R/parsnip-adam_data.R
+++ b/R/parsnip-adam_data.R
@@ -196,7 +196,7 @@ make_adam_reg <- function(){
         value         = list(
             interface = "data.frame",
             protect   = c("x", "y"),
-            func      = c(fun = "adam_fit_impl"),
+            func      = c(pkg = "modeltime", fun = "adam_fit_impl"),
             defaults  = list()
         )
     )
@@ -405,7 +405,7 @@ make_adam_reg <- function(){
         value         = list(
             interface = "data.frame",
             protect   = c("x", "y"),
-            func      = c(fun = "auto_adam_fit_impl"),
+            func      = c(pkg = "modeltime", fun = "auto_adam_fit_impl"),
             defaults  = list()
         )
     )

--- a/R/parsnip-arima_boost_data.R
+++ b/R/parsnip-arima_boost_data.R
@@ -164,7 +164,7 @@ make_arima_boost <- function() {
         value         = list(
             interface = "data.frame",
             protect   = c("x", "y"),
-            func      = c(fun = "auto_arima_xgboost_fit_impl"),
+            func      = c(pkg = "modeltime", fun = "auto_arima_xgboost_fit_impl"),
             defaults  = list(objective = "reg:squarederror", nthread = 1, verbose = 0)
         )
     )
@@ -343,7 +343,7 @@ make_arima_boost <- function() {
         value         = list(
             interface = "data.frame",
             protect   = c("x", "y"),
-            func      = c(fun = "arima_xgboost_fit_impl"),
+            func      = c(pkg = "modeltime", fun = "arima_xgboost_fit_impl"),
             defaults  = list(objective = "reg:squarederror", nthread = 1, verbose = 0)
         )
     )

--- a/R/parsnip-arima_reg_data.R
+++ b/R/parsnip-arima_reg_data.R
@@ -103,7 +103,7 @@ make_arima_reg <- function() {
         value         = list(
             interface = "data.frame",
             protect   = c("x", "y"),
-            func      = c(fun = "Arima_fit_impl"),
+            func      = c(pkg = "modeltime", fun = "Arima_fit_impl"),
             defaults  = list(method = "ML")
         )
     )
@@ -218,7 +218,7 @@ make_arima_reg <- function() {
         value         = list(
             interface = "data.frame",
             protect   = c("x", "y"),
-            func      = c(fun = "auto_arima_fit_impl"),
+            func      = c(pkg = "modeltime", fun = "auto_arima_fit_impl"),
             defaults  = list()
         )
     )

--- a/R/parsnip-exp_smoothing_data.R
+++ b/R/parsnip-exp_smoothing_data.R
@@ -107,7 +107,7 @@ make_exp_smoothing <- function() {
         value         = list(
             interface = "data.frame",
             protect   = c("x", "y"),
-            func      = c(fun = "ets_fit_impl"),
+            func      = c(pkg = "modeltime", fun = "ets_fit_impl"),
             defaults  = list()
         )
     )
@@ -170,7 +170,7 @@ make_exp_smoothing <- function() {
         value         = list(
             interface = "data.frame",
             protect   = c("x", "y"),
-            func      = c(fun = "croston_fit_impl"),
+            func      = c(pkg = "modeltime", fun = "croston_fit_impl"),
             defaults  = list()
         )
     )
@@ -223,7 +223,7 @@ make_exp_smoothing <- function() {
         value         = list(
             interface = "data.frame",
             protect   = c("x", "y"),
-            func      = c(fun = "theta_fit_impl"),
+            func      = c(pkg = "modeltime", fun = "theta_fit_impl"),
             defaults  = list()
         )
     )
@@ -349,7 +349,7 @@ make_exp_smoothing <- function() {
         value         = list(
             interface = "data.frame",
             protect   = c("x", "y"),
-            func      = c(fun = "smooth_fit_impl"),
+            func      = c(pkg = "modeltime", fun = "smooth_fit_impl"),
             defaults  = list()
         )
     )

--- a/R/parsnip-naive_reg_data.R
+++ b/R/parsnip-naive_reg_data.R
@@ -57,7 +57,7 @@ make_naive_reg <- function() {
         value         = list(
             interface = "data.frame",
             protect   = c("x", "y"),
-            func      = c(fun = "naive_fit_impl"),
+            func      = c(pkg = "modeltime", fun = "naive_fit_impl"),
             defaults  = list()
         )
     )
@@ -126,7 +126,7 @@ make_naive_reg <- function() {
         value         = list(
             interface = "data.frame",
             protect   = c("x", "y"),
-            func      = c(fun = "snaive_fit_impl"),
+            func      = c(pkg = "modeltime", fun = "snaive_fit_impl"),
             defaults  = list()
         )
     )

--- a/R/parsnip-nnetar_reg_data.R
+++ b/R/parsnip-nnetar_reg_data.R
@@ -105,7 +105,7 @@ make_nnetar_reg <- function() {
         value         = list(
             interface = "data.frame",
             protect   = c("x", "y"),
-            func      = c(fun = "nnetar_fit_impl"),
+            func      = c(fpkg = "modeltime", un = "nnetar_fit_impl"),
             defaults  = list()
         )
     )

--- a/R/parsnip-prophet_boost_data.R
+++ b/R/parsnip-prophet_boost_data.R
@@ -216,7 +216,7 @@ make_prophet_boost <- function() {
         value         = list(
             interface = "data.frame",
             protect   = c("x", "y"),
-            func      = c(fun = "prophet_xgboost_fit_impl"),
+            func      = c(pkg = "modeltime", fun = "prophet_xgboost_fit_impl"),
             defaults  = list(uncertainty.samples = 0,
                              objective = "reg:squarederror",
                              nthread = 1,

--- a/R/parsnip-prophet_reg_data.R
+++ b/R/parsnip-prophet_reg_data.R
@@ -148,7 +148,7 @@ make_prophet_reg <- function() {
         value         = list(
             interface = "data.frame",
             protect   = c("x", "y"),
-            func      = c(fun = "prophet_fit_impl"),
+            func      = c(pkg = "modeltime", fun = "prophet_fit_impl"),
             defaults  = list(
                 uncertainty.samples = 0
             )

--- a/R/parsnip-seasonal_reg_data.R
+++ b/R/parsnip-seasonal_reg_data.R
@@ -67,7 +67,7 @@ make_seasonal_reg <- function() {
         value         = list(
             interface = "data.frame",
             protect   = c("x", "y"),
-            func      = c(fun = "tbats_fit_impl"),
+            func      = c(pkg = "modeltime", fun = "tbats_fit_impl"),
             defaults  = list(use.parallel = FALSE)
         )
     )
@@ -147,7 +147,7 @@ make_seasonal_reg <- function() {
         value         = list(
             interface = "data.frame",
             protect   = c("x", "y"),
-            func      = c(fun = "stlm_ets_fit_impl"),
+            func      = c(pkg = "modeltime", fun = "stlm_ets_fit_impl"),
             defaults  = list()
         )
     )
@@ -227,7 +227,7 @@ make_seasonal_reg <- function() {
         value         = list(
             interface = "data.frame",
             protect   = c("x", "y"),
-            func      = c(fun = "stlm_arima_fit_impl"),
+            func      = c(pkg = "modeltime", fun = "stlm_arima_fit_impl"),
             defaults  = list()
         )
     )

--- a/R/parsnip-temporal_hierarchy_data.R
+++ b/R/parsnip-temporal_hierarchy_data.R
@@ -68,7 +68,7 @@ make_temporal_hierarchy <- function() {
         value         = list(
             interface = "data.frame",
             protect   = c("x", "y"),
-            func      = c(fun = "temporal_hier_fit_impl"),
+            func      = c(pkg = "modeltime", fun = "temporal_hier_fit_impl"),
             defaults  = list()
         )
     )

--- a/R/parsnip-window_reg_data.R
+++ b/R/parsnip-window_reg_data.R
@@ -66,7 +66,7 @@ make_window_reg <- function() {
         value         = list(
             interface = "data.frame",
             protect   = c("x", "y"),
-            func      = c(fun = "window_function_fit_impl"),
+            func      = c(pkg = "modeltime", fun = "window_function_fit_impl"),
             defaults  = list()
         )
     )


### PR DESCRIPTION
Hi,

we noticed an issue while using the arima regression in a package through parsnip.

As stated in the [tidymodels documentation](https://www.tidymodels.org/learn/develop/models/) in the call to the `parsnip::set_fit` function the `func` argument has to contain the correct package as well as the correct function.

In the current implementation, `func` is assumed to be a local function in the global environment which only works if modeltime is attached, e.g. by `library('modeltime')`.
This fails when an arima model is used inside of an r package.

This fix adds the `pkg` specification for the calls to `parsnip::set_fit`.